### PR TITLE
Add rudimentary Windows support

### DIFF
--- a/lib/platform.js
+++ b/lib/platform.js
@@ -61,6 +61,10 @@ Platform.prototype.populate = function () {
   var hostsfile, self = this;
 
   switch (os.platform()) {
+     case 'win32':
+  	   self.parseResolv();
+  	   hostsfile = process.env.SystemRoot + '\\System32\\drivers\\etc\\hosts';
+  	   break;
     default:
       fs.watchFile('/etc/resolv.conf', {persistent: false}, function (cur, prev) {
         if (cur.mtime !== prev.mtime) {
@@ -70,15 +74,15 @@ Platform.prototype.populate = function () {
       });
       this.parseResolv();
       hostsfile = '/etc/hosts';
+      
+      fs.watchFile(hostsfile, { persistent: false }, function (cur, prev) {
+    	  if (cur.mtime !== prev.mtime) {
+          self.initHostsFile();
+          self.parseHosts(hostsfile);
+        }
+      });
       break;
   }
-
-  fs.watchFile(hostsfile, { persistent: false }, function (cur, prev) {
-    if (cur.mtime !== prev.mtime) {
-      self.initHostsFile();
-      self.parseHosts(hostsfile);
-    }
-  });
 
   this.parseHosts(hostsfile);
 };
@@ -92,52 +96,65 @@ Platform.prototype.checkReady = function () {
 Platform.prototype.parseResolv = function () {
   var self = this;
 
-  fs.readFile('/etc/resolv.conf', 'ascii', function (err, file) {
-    if (err) {
-      throw err;
-    }
-
-    file.split(/\n/).forEach(function (line) {
-      var i, parts, subparts;
-      line = line.replace(/^\s+|\s+$/g, '');
-      if (!line.match(/^#/)) {
-        parts = line.split(/\s+/);
-        switch (parts[0]) {
-        case 'nameserver':
-          self.name_servers.push({
-            address: parts[1],
-            port: 53,
-          });
-          break;
-        case 'domain':
-          self.search_path = parts[1];
-          break;
-        case 'search':
-          self.search_path = parts.slice(1);
-          break;
-        case 'options':
-          for (i = 1; i < parts.length; i++) {
-            subparts = parts[i].split(/:/);
-            switch (subparts[0]) {
-            case 'timeout':
-              self.timeout = parseInt(subparts[1], 10) * 1000;
-              break;
-            case 'attempts':
-              self.attempts = parseInt(subparts[1], 10);
-              break;
-            case 'edns0':
-              self.edns = true;
-              break;
-            }
-          }
-          break;
-        }
-      }
-    });
-
-    self.name_server_ready = true;
-    self.checkReady();
-  });
+  switch (os.platform()) {
+	  case 'win32':
+	    // doing this properly under Windows probably requires a native Node Addon to call GetNetworkParams (http://msdn.microsoft.com/en-us/library/aa365968(VS.85).aspx)
+  	  // ...or apply some ugly regex to the stdout of "ipconfig.exe /all"
+  	  // let's fake it!
+	  self.name_servers.push({
+	  	 address: '8.8.8.8',
+	  	 port: 53
+	  });
+	  break;
+	  default:
+	  fs.readFile('/etc/resolv.conf', 'ascii', function (err, file) {
+	    if (err) {
+	      throw err;
+	    }
+	
+	    file.split(/\n/).forEach(function (line) {
+	      var i, parts, subparts;
+	      line = line.replace(/^\s+|\s+$/g, '');
+	      if (!line.match(/^#/)) {
+	        parts = line.split(/\s+/);
+	        switch (parts[0]) {
+	        case 'nameserver':
+	          self.name_servers.push({
+	            address: parts[1],
+	            port: 53,
+	          });
+	          break;
+	        case 'domain':
+	          self.search_path = parts[1];
+	          break;
+	        case 'search':
+	          self.search_path = parts.slice(1);
+	          break;
+	        case 'options':
+	          for (i = 1; i < parts.length; i++) {
+	            subparts = parts[i].split(/:/);
+	            switch (subparts[0]) {
+	            case 'timeout':
+	              self.timeout = parseInt(subparts[1], 10) * 1000;
+	              break;
+	            case 'attempts':
+	              self.attempts = parseInt(subparts[1], 10);
+	              break;
+	            case 'edns0':
+	              self.edns = true;
+	              break;
+	            }
+	          }
+	          break;
+	        }
+	      }
+	    });
+	
+	    self.name_server_ready = true;
+	    self.checkReady();
+	  });
+  break;
+  }
 };
 
 Platform.prototype.parseHosts = function (hostsfile) {


### PR DESCRIPTION
AKA fix it so it doesn't crash as soon as you start up.

Under Windows, /etc/hosts and /etc/resolv.conf obviously don't exist.  This patches platform.js so that you can at least get up and running under Windows.
- Looks for the hosts file at %SYSTEMROOT%\System32\drivers\etc\hosts - seems to work
- Getting the system's configured nameservers is a bit trickier.  There's a Win32 API available (`GetNetworkParams`), but that means building a native Addon.  You could also parse the output of `ipconfig.exe /all`, but that feels ugly.  I just faked it for now using Google's public DNS servers.
