### PR TITLE
Serve on process.nextTick

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -84,8 +84,9 @@ var UDPServer = function(opts) {
 util.inherits(UDPServer, Server);
 
 UDPServer.prototype.serve = function(port, address) {
+  var self = this;
   process.nextTick(function() {
-    this._socket.bind(port, address);
+    self._socket.bind(port, address);
   });
 };
 


### PR DESCRIPTION
This is so that you can attach listeners after calling server.serve();

``` js
server.serve();
server.on('listening', function() {
  // oh yeah!
});
```
