### PR TITLE
Platform didn't become "ready" on Win32 systems

### DIFF
--- a/lib/platform.js
+++ b/lib/platform.js
@@ -51,6 +51,7 @@ var Platform = function() {
       return Object.keys(this._watches).length > 0;
     },
     set: function(value) {
+      var k;
       if (value)
         this._watchFiles();
       else {
@@ -241,7 +242,7 @@ Platform.prototype._parseHosts = function(hostsfile) {
               class: 1,
               name: revip,
               data: domain,
-              ttl: Infinity,
+              ttl: Infinity
             });
           });
 
@@ -259,7 +260,7 @@ Platform.prototype._parseHosts = function(hostsfile) {
               type: type,
               name: domain.toLowerCase(),
               address: ip,
-              ttl: Infinity,
+              ttl: Infinity
             });
           });
         }


### PR DESCRIPTION
node-dns has hardcoded DNS servers for Win32 platform. So, `parseResolv` didn't get called at module init and `this._nsReady` is not become `true`.

Also one of Google DNS is misstyped to "8.8.4.4." (not a trailing dot).
