### PR TITLE
Fix the issue #51 that crashed the server on Linux.

### DIFF
--- a/lib/platform.js
+++ b/lib/platform.js
@@ -268,7 +268,7 @@ Platform.prototype._parseHosts = function(hostsfile) {
     });
 
     Object.keys(toStore).forEach(function (key) {
-      self.hosts._store.set(self.hosts._zone, key, toStore[key]);
+      self.hosts._store._store.set(self.hosts._zone, key, toStore[key]);
     });
     self._hostsReady = true;
     self._checkReady();


### PR DESCRIPTION
With this slight change, a Node.js server that imports the module still works with Windows but now works too with Linux.

The hosts object contains a _store that's an object containing itself a _store. The access to the second one was missing.

{ _zone: '.',
  _store: 
   { _store: { _store: [Object] },  <----
     _zone: '.',
     _max_keys: undefined,
     _ttl: { length: 0, root: undefined, _comparator: [Function] } },
  purge: [Function] }

It would solve the issue #51 and it would be great to push it to NPM as well.

Thanks.
