### PR TITLE
Add support for TLSA

### DIFF
--- a/dns.js
+++ b/dns.js
@@ -64,6 +64,7 @@ var definedTypes = [
   'MX',
   'SRV',
   'SOA',
+  'TLSA',
 ].forEach(function (type) {
   exports[type] = function (opts) {
     var obj = {};

--- a/lib/client.js
+++ b/lib/client.js
@@ -37,7 +37,8 @@ var A = consts.NAME_TO_QTYPE.A,
     NS = consts.NAME_TO_QTYPE.NS,
     CNAME = consts.NAME_TO_QTYPE.CNAME,
     SRV = consts.NAME_TO_QTYPE.SRV,
-    PTR = consts.NAME_TO_QTYPE.PTR;
+    PTR = consts.NAME_TO_QTYPE.PTR,
+    TLSA = consts.NAME_TO_QTYPE.TLSA;
 
 var debug = function() {
   //var args = Array.prototype.slice.call(arguments);
@@ -519,6 +520,13 @@ var resolveCname = function(domain, callback) {
   });
 };
 exports.resolveCname = resolveCname;
+
+var resolveTlsa = function(domain, callback) {
+  return resolve(domain, 'TLSA', function(err, results) {
+    callback(err, results);
+  });
+};
+exports.resolveTlsa = resolveTlsa;
 
 var reverse = function(ip, callback) {
   var error, opts, res;


### PR DESCRIPTION
Add support for TLSA records, as defined in [RFC 6698](http://tools.ietf.org/html/rfc6698).

Requires https://github.com/tjfontaine/native-dns-packet/pull/3
