### PR TITLE
Make it not fail if it can't find /etc/resolv.conf

### DIFF
--- a/lib/platform.js
+++ b/lib/platform.js
@@ -163,9 +163,12 @@ Platform.prototype.parseResolv = function() {
 
   fs.readFile('/etc/resolv.conf', 'ascii', function(err, file) {
     if (err) {
+      // If the file wasn't found don't worry about it.
+      if (err.code == 'ENOENT') {
+        return;
+      }
       throw err;
     }
-
     file.split(/\n/).forEach(function(line) {
       var i, parts, subparts;
       line = line.replace(/^\s+|\s+$/g, '');


### PR DESCRIPTION
On OSX /etc/resolv.conf is generated by the OS anytime the network
changes. If I create a network "By picking 'Create Network...'" from
the wifi menu then there is no /etc/resolv.conf and the throw
that was here would .. uh, .. throw.

Making it not throw makes the dns-server work for my purposes.

I don't know if this is how you like to deal with that or if you'd like some flag or check or OSX only or what but I thought I'd at least pass on what I needed to do to get it to work for me.