### PR TITLE
Allow setting header flags on Request creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ request to finish. (optional, default 4000)
  * `cache` -- can be false to disable caching, or implement the cache model, or
 an instance of Cache but with a different store (optional, default
 platform.cache)
+ * `header` -- an object containing header flags (optional)
 
 There are only two methods
 

--- a/lib/client.js
+++ b/lib/client.js
@@ -51,6 +51,7 @@ debug = function debug() {
 var Request = exports.Request = function(opts) {
   if (!(this instanceof Request)) return new Request(opts);
 
+  this.header = opts.header;
   this.question = opts.question;
   this.server = opts.server;
 

--- a/lib/pending.js
+++ b/lib/pending.js
@@ -100,7 +100,7 @@ var random_integer = function() {
 
 SocketQueue.prototype._dequeue = function() {
   var req = this._pending.pop();
-  var id, packet, dnssocket;
+  var id, packet, dnssocket, k;
 
   if (req) {
     id = random_integer();
@@ -118,6 +118,13 @@ SocketQueue.prototype._dequeue = function() {
       packet = new Packet(this._socket.remote(req.server));
       packet.header.id = id;
       packet.header.rd = 1;
+      if (req.header) {
+        for (k in req.header) {
+          if (k in packet.header) {
+            packet.header[k] = req.header[k];
+          }
+        }
+      }
 
       if (req.try_edns) {
         packet.edns_version = 0;


### PR DESCRIPTION
In my specific case I needed to modify the `opcode` header flag but I noticed that there was a request for another flag to be modified as well (see #64) so I made the change more generic to allow any header flag to be set.
