### PR TITLE
Fix exceptions when no nameservers are defined on platform

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -251,6 +251,12 @@ Resolve.prototype._fillServers = function() {
 
   slist = platform.name_servers;
 
+  if (slist.length === 0) {
+    // No nameservers defined on platform, so this._server_list
+    // stays empty.
+    return;
+  }
+
   while (this._server_list.length < platform.attempts) {
     s = slist[tries % slist.length];
 

--- a/lib/client.js
+++ b/lib/client.js
@@ -306,7 +306,7 @@ Resolve.prototype.start = function() {
 
   if (this._server_list.length === 0) {
     debug('resolve no more servers', this._domain);
-    this.handleTimeout();
+    this._handleTimeout();
   } else {
     this._current_server = this._server_list.pop();
     debug('resolve start', this._current_server, this._domain);

--- a/test/client.js
+++ b/test/client.js
@@ -396,6 +396,15 @@ exports.lookup_longname = function (test) {
   checkWrap(test, request);
 };
 
+exports.lookup_without_nameservers = function(test) {
+  platform.name_servers = [];
+  dns.lookup('www.google.com', function(err) {
+    test.ok(err, 'we should fail');
+    test.strictEqual(err.errno, dns.TIMEOUT);
+    test.done();
+    fixupDns();
+  });
+};
 
 /* Disabled because it appears to be not working on linux. */
 /*


### PR DESCRIPTION
When `resolv.conf` was empty, node-dns would give exceptions when resolving names. The exception happened in Resolve._fillServers and once that was fixed an exception was happened in Resolve.start.

I've tested the unit test with some additional fixes, so that some of the existing tests pass. I'll do a seperate PR for these unit test fixes.