### PR TITLE
add Node 0.10 to Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ node_js:
    - 0.6
    - 0.8
    - 0.9
+   - 0.10
 notifications:
   irc:
     channels:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
 language: node_js
 node_js:
-   - 0.6
-   - 0.8
-   - 0.9
-   - 0.10
+   - "0.6"
+   - "0.8"
+   - "0.9"
+   - "0.10"
 notifications:
   irc:
     channels:


### PR DESCRIPTION
At the moment the build fails for Node 0.9, 0.8, 0.6 because, somehow, verror cannot be installed for these engines. Node 0.10 should work and when the fixes for the unit tests are merged (https://github.com/tjfontaine/node-dns/pull/83) then Travis should be able to run everything succesfully for Node 0.10.

I'm not sure what to do about verror, because that's referenced from http://github.com/tjfontaine/node-buffercursor.