### PR TITLE
0.8.0, pass socket.bind options to client.resolve

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -54,6 +54,7 @@ var Request = exports.Request = function(opts) {
 
   this.question = opts.question;
   this.server = opts.server;
+  this.bind_options = opts.bind_options;
 
   if (typeof(this.server) === 'string' || this.server instanceof String)
     this.server = { address: this.server, port: 53, type: 'udp'};
@@ -193,6 +194,8 @@ var Resolve = function Resolve(opts, cb) {
 
   this._server_list = [];
 
+  this.bind_options = opts.bind_options;
+
   if (opts.remote) {
     this._server_list.push({
       address: opts.remote,
@@ -321,7 +324,8 @@ Resolve.prototype.start = function() {
       question: this.question,
       server: this._current_server,
       timeout: platform.timeout,
-      try_edns: this.try_edns
+      try_edns: this.try_edns,
+      bind_options: this.bind_options
     });
 
     this._request.on('timeout', this._handleTimeout.bind(this));
@@ -424,12 +428,12 @@ Resolve.prototype._handleTimeout = function() {
   }
 };
 
-var resolve = function(domain, rrtype, ip, callback) {
+var resolve = function(domain, rrtype, options, callback) {
   var res;
 
   if (!callback) {
-    callback = ip;
-    ip = undefined;
+    callback = options;
+    options = undefined;
   }
 
   if (!callback) {
@@ -443,10 +447,14 @@ var resolve = function(domain, rrtype, ip, callback) {
     return reverse(domain, callback);
   }
 
+  var ip = typeof options === 'string' ? options : options && options.ip;
+  var bind_options = options !== null && typeof options === 'object' ? options : undefined;
+
   var opts = {
     domain: domain,
     rrtype: rrtype,
     remote: ip,
+    bind_options: bind_options
   };
 
   res = new Resolve(opts);

--- a/lib/pending.js
+++ b/lib/pending.js
@@ -231,7 +231,7 @@ exports.send = function(request) {
     switch (hash) {
       case 'udp4':
       case 'udp6':
-        socket = new SocketQueue(new UDPSocket(), hash);
+        socket = new SocketQueue(new UDPSocket(undefined, undefined, request.bind_options), hash);
         break;
       default:
         socket = new SocketQueue(new TCPSocket(), request.server);

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -24,7 +24,7 @@ var dgram = require('dgram'),
     net = require('net'),
     util = require('util');
 
-var UDPSocket = exports.UDPSocket = function(socket, remote) {
+var UDPSocket = exports.UDPSocket = function(socket, remote, bind_options) {
   this._socket = socket;
   this._remote = remote;
   this._buff = undefined;
@@ -32,6 +32,7 @@ var UDPSocket = exports.UDPSocket = function(socket, remote) {
   this.bound = false;
   this.unref = undefined;
   this.ref = undefined;
+  this.bind_options = bind_options;
 };
 util.inherits(UDPSocket, EventEmitter);
 
@@ -57,10 +58,10 @@ UDPSocket.prototype.bind = function(type) {
       if (self._socket.unref) {
         self.unref = function() {
           self._socket.unref();
-        }
+        };
         self.ref = function() {
           self._socket.ref();
-        }
+        };
       }
       self.emit('ready');
     });
@@ -72,7 +73,7 @@ UDPSocket.prototype.bind = function(type) {
       self.emit('close');
     });
 
-    this._socket.bind();
+    this._socket.bind(this.bind_options);
   }
 };
 
@@ -81,7 +82,7 @@ UDPSocket.prototype.close = function() {
 };
 
 UDPSocket.prototype.remote = function(remote) {
-  return new UDPSocket(this._socket, remote);
+  return new UDPSocket(this._socket, remote, this.bind_options);
 };
 
 var TCPSocket = exports.TCPSocket = function(socket) {
@@ -114,10 +115,10 @@ TCPSocket.prototype.bind = function(server) {
       if (self._socket.unref) {
         self.unref = function() {
           self._socket.unref();
-        }
+        };
         self.ref = function() {
           self._socket.ref();
-        }
+        };
       }
       self.emit('ready');
     });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "native-dns",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "authors": [
     "Timothy J Fontaine <tjfontaine@gmail.com> (http://atxconsulting.com)",
     "Greg Slepak <contact@taoeffect.com> (https://twitter.com/taoeffect)",


### PR DESCRIPTION
Added the ability to send socket.bind options via the ip parameter (now named options, but it's backwards compatible) in the client.resolve method.  This allows us to set the socket as exclusive, which makes it play nice with clustering.  https://github.com/joyent/node/issues/2194

UDP Sockets are supposed to be exclusive by default, however, we're running node 0.12.7 and aren't seeing this behavior.  node-dns falls apart with clustering enabled and multiple workers unless we explicitly set exclusive to true.

I wasn't sure how to run tests (npm test just hangs after outputting 'client' to the console), but benchmark seems to handle regression fine and supports the changes.
