### PR TITLE
Handle client in tcp mode losing connection.

### DIFF
--- a/lib/pending.js
+++ b/lib/pending.js
@@ -28,10 +28,14 @@ var net = require('net'),
     UDPSocket = require('./utils').UDPSocket,
     TCPSocket = require('./utils').TCPSocket;
 
-var debug = function() {
-  //var args = Array.prototype.slice.call(arguments);
-  //console.log.apply(this, ['pending', Date.now().toString()].concat(args));
+var debug = function() {};
+
+if (process.env.NODE_DEBUG && process.env.NODE_DEBUG.match(/dns/)) {
+debug = function debug() {
+  var args = Array.prototype.slice.call(arguments);
+  console.log.apply(this, ['pending', Date.now().toString()].concat(args));
 };
+}
 
 var SocketQueue = function(socket, server) {
   this._active = {};
@@ -77,8 +81,6 @@ SocketQueue.prototype.remove = function(request) {
 SocketQueue.prototype.close = function() {
   debug('closing', this._server);
   this._socket.close();
-  this._socket = undefined;
-  this.emit('close');
 };
 
 SocketQueue.prototype._fill = function() {
@@ -197,6 +199,8 @@ SocketQueue.prototype._onclose = function() {
   debug('socket closed', this);
 
   this._listening = false;
+  this._socket = undefined;
+  this.emit('close');
 
   err = new Error('getHostByName ' + consts.TIMEOUT);
   err.errno = consts.TIMEOUT;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "native-dns",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "authors": [
     "Timothy J Fontaine <tjfontaine@gmail.com> (http://atxconsulting.com)",
     "Greg Slepak <contact@taoeffect.com> (https://twitter.com/taoeffect)",


### PR DESCRIPTION
When there are no activities in the tcp connection, the remote server may close
the connection.  Properly handle this scenario so that the SocketQueue is not
holding on to a closed TCP socket; but trigger the SocketQueue to be destroyed
so that it will be re-created on the next send.
